### PR TITLE
Fix issues in array chunking

### DIFF
--- a/philote_mdo/utils/__init__.py
+++ b/philote_mdo/utils/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 from .pair_dict import PairDict
+from .helper import get_chunk_indicies, get_flattened_view

--- a/philote_mdo/utils/helper.py
+++ b/philote_mdo/utils/helper.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+def get_chunk_indicies(num_values, chunk_size):
+    beg_i = np.arange(0, num_values, chunk_size)
+
+    if beg_i.size == 1:
+        end_i = [num_values]
+    else:
+        end_i = np.append(beg_i[1:], [num_values])
+
+    return zip(beg_i, end_i)
+
+def get_flattened_view(arr):
+    """
+    Returns a flattened view of the input array. Used instead of reshape, ravel, flatten, etc. to guarante a copy is
+    not made. If the input array does not support copy-free modification, AttributeError will be thrown
+    :param arr: Array to get a flattened view
+    :return: A view of the input array, guaranteed to not be a copy
+    """
+    flat_view = arr.view()
+    flat_view.shape = (-1)
+    return flat_view


### PR DESCRIPTION
1. Changed flat array allocation to use method that does not create copies
2. Added missing end index when generating chunk indicies. The semantics of np.arrange generates values up to but not including the stop value so the end index list was missing the last chunk, causing the last chunk to not be sent
3. Created helper functions for flat views and chunk indicies to reduce repeated code