### PR TITLE
Fix two proto conformance bugs in GetInfo and the implicit server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Fixed `ImplicitServer` emitting `Array.end` as an exclusive index, while the
+  explicit server and both clients treat it as inclusive per the standard.  Any
+  implicit variable spanning more than one chunk failed to decode; single-chunk
+  arrays were masked by NumPy slice clipping (#66).
 - Fixed the `GetInfo` RPC, which was implemented as a generator on the server
   and indexed as a stream on the client, even though the proto declares it as
   unary.  Every call failed with `Failed to serialize response!`.  The server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Fixed the `GetInfo` RPC, which was implemented as a generator on the server
+  and indexed as a stream on the client, even though the proto declares it as
+  unary.  Every call failed with `Failed to serialize response!`.  The server
+  now returns a `DisciplineProperties` message and the client reads it
+  directly (#67).
+- The server now populates the `name` and `version` fields of
+  `DisciplineProperties` from the discipline's `_name` / `_version`
+  attributes, and the client stores them (#67).
+
 ## [0.8.0] - 2026-05-16
 
 ### Features

--- a/philote_mdo/general/discipline.py
+++ b/philote_mdo/general/discipline.py
@@ -44,6 +44,8 @@ class Discipline:
 
     def __init__(self):
         # discipline properties
+        self._name = ""
+        self._version = ""
         self._is_continuous = False
         self._is_differentiable = False
         self._provides_gradients = False

--- a/philote_mdo/general/discipline_client.py
+++ b/philote_mdo/general/discipline_client.py
@@ -53,6 +53,8 @@ class DisciplineClient:
         self.grpc_options = []
 
         # discipline properties
+        self._name = ""
+        self._version = ""
         self._is_continuous = False
         self._is_differentiable = False
         self._provides_gradients = False
@@ -76,9 +78,11 @@ class DisciplineClient:
         Gets the discipline properties from the analysis server.
         """
         response = self._disc_stub.GetInfo(empty.Empty())
-        self._is_continuous = response[0].continuous
-        self._is_differentiable = response[0].differentiable
-        self._provides_gradients = response[0].provides_gradients
+        self._is_continuous = response.continuous
+        self._is_differentiable = response.differentiable
+        self._provides_gradients = response.provides_gradients
+        self._name = response.name
+        self._version = response.version
 
     def send_stream_options(self):
         """

--- a/philote_mdo/general/discipline_server.py
+++ b/philote_mdo/general/discipline_server.py
@@ -68,10 +68,12 @@ class DisciplineServer(disc.DisciplineService):
         """
         RPC that sends the discipline information/properties to the client.
         """
-        yield data.DisciplineProperties(
+        return data.DisciplineProperties(
             continuous=self._discipline._is_continuous,
             differentiable=self._discipline._is_differentiable,
             provides_gradients=self._discipline._provides_gradients,
+            name=self._discipline._name,
+            version=self._discipline._version,
         )
 
     def SetStreamOptions(self, request, context):

--- a/philote_mdo/general/implicit_server.py
+++ b/philote_mdo/general/implicit_server.py
@@ -189,7 +189,7 @@ class ImplicitServer(pmdo.DisciplineServer, disc.ImplicitServiceServicer):
                         continuous=data.Array(
                             name=res_name,
                             start=b,
-                            end=e,
+                            end=e - 1,
                             type=data.kResidual,
                             data=value.ravel()[b:e],
                         )
@@ -256,7 +256,7 @@ class ImplicitServer(pmdo.DisciplineServer, disc.ImplicitServiceServicer):
                         continuous=data.Array(
                             name=output_name,
                             start=b,
-                            end=e,
+                            end=e - 1,
                             type=data.kOutput,
                             data=value.ravel()[b:e],
                         )
@@ -330,7 +330,7 @@ class ImplicitServer(pmdo.DisciplineServer, disc.ImplicitServiceServicer):
                             subname=jac[1],
                             type=data.kPartial,
                             start=b,
-                            end=e,
+                            end=e - 1,
                             data=value.ravel()[b:e],
                         )
                     )

--- a/tests/test_discipline_client.py
+++ b/tests/test_discipline_client.py
@@ -70,11 +70,13 @@ class TestDisciplineClient(unittest.TestCase):
         """
         mock_channel = Mock()
         mock_stub = mock_discipline_stub.return_value
-        mock_stub.GetInfo.return_value = [
-            data.DisciplineProperties(
-                continuous=True, differentiable=True, provides_gradients=True
-            )
-        ]
+        mock_stub.GetInfo.return_value = data.DisciplineProperties(
+            continuous=True,
+            differentiable=True,
+            provides_gradients=True,
+            name="TestDiscipline",
+            version="1.2.3",
+        )
 
         client = DisciplineClient(mock_channel)
         client.get_discipline_info()
@@ -83,6 +85,8 @@ class TestDisciplineClient(unittest.TestCase):
         self.assertTrue(client._is_continuous)
         self.assertTrue(client._is_differentiable)
         self.assertTrue(client._provides_gradients)
+        self.assertEqual(client._name, "TestDiscipline")
+        self.assertEqual(client._version, "1.2.3")
 
     @patch("philote_mdo.generated.disciplines_pb2_grpc.DisciplineServiceStub")
     def test_send_stream_options(self, mock_discipline_stub):

--- a/tests/test_discipline_server.py
+++ b/tests/test_discipline_server.py
@@ -54,24 +54,24 @@ class TestDisciplineServer(unittest.TestCase):
         server._discipline._is_continuous = True
         server._discipline._is_differentiable = True
         server._discipline._provides_gradients = True
+        server._discipline._name = "TestDiscipline"
+        server._discipline._version = "1.2.3"
 
         # mock arguments
         context = Mock()
         request = Empty()
 
-        response_generator = server.GetInfo(request, context)
+        # GetInfo is a unary RPC, so it must return a message (not a generator)
+        response = server.GetInfo(request, context)
 
-        # Generate responses and collect them into a list
-        responses = list(response_generator)
-
-        # check that there is only one response
-        self.assertEqual(len(responses), 1)
+        self.assertIsInstance(response, data.DisciplineProperties)
 
         # check the values of the response
-        response = responses[0]
         self.assertTrue(response.continuous)
         self.assertTrue(response.differentiable)
         self.assertTrue(response.provides_gradients)
+        self.assertEqual(response.name, "TestDiscipline")
+        self.assertEqual(response.version, "1.2.3")
 
     def test_set_stream_options(self):
         """

--- a/tests/test_implicit_server.py
+++ b/tests/test_implicit_server.py
@@ -61,9 +61,9 @@ class TestImplicitServer(unittest.TestCase):
 
         # mock request iterator
         mock_request_iterator = [
-            data.VariableMessage(continuous=data.Array(name="x", start=0, end=2, type=data.kInput, data=[1.0, 2.0])),
-            data.VariableMessage(continuous=data.Array(name="y", start=0, end=2, type=data.kInput, data=[3.0, 4.0])),
-            data.VariableMessage(continuous=data.Array(name="f", start=0, end=2, type=data.kOutput, data=[5.0, 6.0])),
+            data.VariableMessage(continuous=data.Array(name="x", start=0, end=1, type=data.kInput, data=[1.0, 2.0])),
+            data.VariableMessage(continuous=data.Array(name="y", start=0, end=1, type=data.kInput, data=[3.0, 4.0])),
+            data.VariableMessage(continuous=data.Array(name="f", start=0, end=1, type=data.kOutput, data=[5.0, 6.0])),
         ]
 
         # mock inputs, outputs, and residuals
@@ -86,13 +86,13 @@ class TestImplicitServer(unittest.TestCase):
         expected_result = [
             data.VariableMessage(
                 continuous=data.Array(
-                    name="f", start=0, end=1,
+                    name="f", start=0, end=0,
                     type=data.VariableType.kResidual, data=[7.0],
                 )
             ),
             data.VariableMessage(
                 continuous=data.Array(
-                    name="f", start=1, end=2,
+                    name="f", start=1, end=1,
                     type=data.VariableType.kResidual, data=[8.0],
                 )
             ),
@@ -116,9 +116,9 @@ class TestImplicitServer(unittest.TestCase):
 
         # mock request iterator
         mock_request_iterator = [
-            data.VariableMessage(continuous=data.Array(name="x", start=0, end=2, type=data.kInput, data=[1.0, 2.0])),
-            data.VariableMessage(continuous=data.Array(name="y", start=0, end=2, type=data.kInput, data=[3.0, 4.0])),
-            data.VariableMessage(continuous=data.Array(name="f", start=0, end=2, type=data.kOutput, data=[5.0, 6.0])),
+            data.VariableMessage(continuous=data.Array(name="x", start=0, end=1, type=data.kInput, data=[1.0, 2.0])),
+            data.VariableMessage(continuous=data.Array(name="y", start=0, end=1, type=data.kInput, data=[3.0, 4.0])),
+            data.VariableMessage(continuous=data.Array(name="f", start=0, end=1, type=data.kOutput, data=[5.0, 6.0])),
         ]
 
         # mock inputs, outputs, and residuals
@@ -141,13 +141,13 @@ class TestImplicitServer(unittest.TestCase):
         expected_result = [
             data.VariableMessage(
                 continuous=data.Array(
-                    name="f", start=0, end=1,
+                    name="f", start=0, end=0,
                     type=data.VariableType.kOutput, data=[7.0],
                 )
             ),
             data.VariableMessage(
                 continuous=data.Array(
-                    name="f", start=1, end=2,
+                    name="f", start=1, end=1,
                     type=data.VariableType.kOutput, data=[8.0],
                 )
             ),
@@ -199,7 +199,8 @@ class TestImplicitServer(unittest.TestCase):
         self.assertEqual(response.name, "f")
         self.assertEqual(response.subname, "x")
         self.assertEqual(response.start, 0)
-        self.assertEqual(response.end, 3)
+        self.assertEqual(response.end, 2)
+        self.assertEqual(len(response.data), response.end - response.start + 1)
         grad = np.array(response.data)
 
         response = responses[1].continuous

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -297,6 +297,40 @@ class StructOptionIntegrationTests(unittest.TestCase):
         finally:
             server.stop(0)
 
+    def test_get_discipline_info(self):
+        """
+        Integration test for the GetInfo RPC (unary on both sides).
+        """
+        # server code
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+
+        discipline = Paraboloid()
+        discipline._name = "Paraboloid"
+        discipline._version = "1.0.0"
+        pmdo.ExplicitServer(discipline=discipline).attach_to_server(server)
+
+        server.add_insecure_port("[::]:50051")
+        server.start()
+
+        try:
+            client = pmdo.ExplicitClient(
+                channel=grpc.insecure_channel("localhost:50051")
+            )
+
+            client.get_discipline_info()
+
+            self.assertEqual(client._is_continuous, discipline._is_continuous)
+            self.assertEqual(
+                client._is_differentiable, discipline._is_differentiable
+            )
+            self.assertEqual(
+                client._provides_gradients, discipline._provides_gradients
+            )
+            self.assertEqual(client._name, "Paraboloid")
+            self.assertEqual(client._version, "1.0.0")
+        finally:
+            server.stop(0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,6 +32,7 @@ import unittest
 import grpc
 import numpy as np
 import philote_mdo.general as pmdo
+import philote_mdo.generated.data_pb2 as data
 from philote_mdo.examples import Paraboloid, QuadradicImplicit
 
 
@@ -221,6 +222,99 @@ class IntegrationTests(unittest.TestCase):
         # stop the server
         server.stop(0)
 
+    def test_implicit_multi_chunk_transfer(self):
+        """
+        Integration test for an implicit variable spanning several chunks.
+
+        Regression test for the implicit server emitting an exclusive
+        Array.end, which broke any variable larger than num_double.
+        """
+
+        class VectorImplicit(pmdo.ImplicitDiscipline):
+            def setup(self):
+                self.add_input("a", shape=(5,))
+                self.add_output("x", shape=(5,))
+                self.declare_partials("x", "a")
+
+            def compute_residuals(self, inputs, outputs, residuals):
+                residuals["x"] = outputs["x"] - inputs["a"]
+
+            def solve_residuals(self, inputs, outputs):
+                outputs["x"] = inputs["a"]
+
+            def residual_partials(self, inputs, outputs, jacobian):
+                jacobian["x", "a"] = -np.eye(5)
+
+        # server code
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+
+        pmdo.ImplicitServer(discipline=VectorImplicit()).attach_to_server(server)
+
+        server.add_insecure_port("[::]:50051")
+        server.start()
+
+        try:
+            client = pmdo.ImplicitClient(
+                channel=grpc.insecure_channel("localhost:50051")
+            )
+
+            # 5 values at 2 per chunk -> 3 chunks per variable
+            client._stream_options = data.StreamOptions(num_double=2)
+            client.send_stream_options()
+
+            client.run_setup()
+            client.get_variable_definitions()
+            client.get_partials_definitions()
+
+            a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+            outputs = client.run_solve_residuals({"a": a})
+            np.testing.assert_allclose(outputs["x"], a)
+
+            residuals = client.run_compute_residuals({"a": a}, {"x": a + 1.0})
+            np.testing.assert_allclose(residuals["x"], np.ones(5))
+
+            jac = client.run_residual_gradients({"a": a}, {"x": a})
+            np.testing.assert_allclose(jac["x", "a"], -np.eye(5))
+        finally:
+            server.stop(0)
+
+    def test_get_discipline_info(self):
+        """
+        Integration test for the GetInfo RPC (unary on both sides).
+        """
+        # server code
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+
+        discipline = Paraboloid()
+        discipline._name = "Paraboloid"
+        discipline._version = "1.0.0"
+        pmdo.ExplicitServer(discipline=discipline).attach_to_server(server)
+
+        server.add_insecure_port("[::]:50051")
+        server.start()
+
+        try:
+            client = pmdo.ExplicitClient(
+                channel=grpc.insecure_channel("localhost:50051")
+            )
+
+            client.get_discipline_info()
+
+            self.assertEqual(client._is_continuous, discipline._is_continuous)
+            self.assertEqual(
+                client._is_differentiable, discipline._is_differentiable
+            )
+            self.assertEqual(
+                client._provides_gradients, discipline._provides_gradients
+            )
+            self.assertEqual(client._name, "Paraboloid")
+            self.assertEqual(client._version, "1.0.0")
+        finally:
+            server.stop(0)
+
+
+
 
 class StructOptionDiscipline(pmdo.ExplicitDiscipline):
     """
@@ -296,41 +390,6 @@ class StructOptionIntegrationTests(unittest.TestCase):
             self.assertAlmostEqual(jac["f", "x"][0], 3.0)
         finally:
             server.stop(0)
-
-    def test_get_discipline_info(self):
-        """
-        Integration test for the GetInfo RPC (unary on both sides).
-        """
-        # server code
-        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-
-        discipline = Paraboloid()
-        discipline._name = "Paraboloid"
-        discipline._version = "1.0.0"
-        pmdo.ExplicitServer(discipline=discipline).attach_to_server(server)
-
-        server.add_insecure_port("[::]:50051")
-        server.start()
-
-        try:
-            client = pmdo.ExplicitClient(
-                channel=grpc.insecure_channel("localhost:50051")
-            )
-
-            client.get_discipline_info()
-
-            self.assertEqual(client._is_continuous, discipline._is_continuous)
-            self.assertEqual(
-                client._is_differentiable, discipline._is_differentiable
-            )
-            self.assertEqual(
-                client._provides_gradients, discipline._provides_gradients
-            )
-            self.assertEqual(client._name, "Paraboloid")
-            self.assertEqual(client._version, "1.0.0")
-        finally:
-            server.stop(0)
-
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes two spec-conformance bugs found while implementing
[Philote-Rust](https://github.com/MDO-Standards/Philote-Rust) against the same proto.

Closes #67
Closes #66

## `GetInfo` was a generator on a unary RPC (#67)

The proto declares `GetInfo` as unary, but the server `yield`ed and the client
indexed `response[0]`. gRPC cannot serialize a generator into a
`DisciplineProperties`, so every call failed with
`StatusCode.INTERNAL | Failed to serialize response!` — including Python client
to Python server.

Both sides had to change together: with the server alone fixed, `response[0]`
raises `TypeError`.

The server now also populates `DisciplineProperties.name` and `.version`, which
were previously always empty. `Discipline` gained `_name` / `_version`
attributes (default `""`) to back them.

## `ImplicitServer` emitted an exclusive `Array.end` (#66)

`Array.end` is inclusive per the standard. The explicit server and both clients
encode and decode it that way; the implicit server wrote the exclusive bound
straight from `get_chunk_indices`, so the client sized its destination slice one
element longer than the payload.

Any implicit variable spanning more than one chunk failed with
`could not broadcast input array from shape (n,) into shape (n+1,)`.
Single-chunk arrays survived by accident — the over-long slice was clipped by
NumPy to the array length, which happened to match the payload.

## Why CI didn't catch either

Both bugs were invisible to the existing suite, so the tests are the substantive
part of this PR:

- `GetInfo` was only ever tested through mocks shaped like the buggy
  implementation (the client mock returned a *list*), and nothing exercised it
  against a real server.
- Every implicit variable in `examples/` and `tests/` is a scalar, so the
  multi-chunk path was never run.

Added:
- `test_get_discipline_info` — end-to-end `GetInfo` against a real gRPC server,
  so the two sides can't drift again.
- `test_implicit_multi_chunk_transfer` — a 5-element implicit variable at
  `num_double=2` (3 chunks per variable, 13 for the 5×5 Jacobian), covering
  `solve_residuals`, `compute_residuals`, and `residual_gradients`.

Both were verified against the pre-fix code and reproduce the exact failures
from the issues.

Corrected the unit tests that encoded the buggy behavior as expected output:
three in `test_implicit_server.py` asserted the exclusive encoding, and two
request fixtures used the exclusive convention on the wire (passing only via the
same NumPy clipping that masked the bug).

## Testing

`pytest tests/` — 280 passed.