### PR TITLE
fix(server): rename loop variable to avoid shadowing jac dict in gradient RPCs

### DIFF
--- a/philote_mdo/general/explicit_server.py
+++ b/philote_mdo/general/explicit_server.py
@@ -126,12 +126,12 @@ class ExplicitServer(DisciplineServer, disc.ExplicitServiceServicer):
             else:
                 self._discipline.compute_partials(inputs, jac)
 
-            for jac, value in jac.items():
+            for key, value in jac.items():
                 for b, e in get_chunk_indices(value.size, self._stream_opts.num_double):
                     yield data.VariableMessage(
                         continuous=data.Array(
-                            name=jac[0],
-                            subname=jac[1],
+                            name=key[0],
+                            subname=key[1],
                             type=data.kPartial,
                             start=b,
                             end=e - 1,

--- a/philote_mdo/general/implicit_server.py
+++ b/philote_mdo/general/implicit_server.py
@@ -322,12 +322,12 @@ class ImplicitServer(pmdo.DisciplineServer, disc.ImplicitServiceServicer):
             else:
                 self._discipline.residual_partials(inputs, outputs, jac)
 
-            for jac, value in jac.items():
+            for key, value in jac.items():
                 for b, e in get_chunk_indices(value.size, self._stream_opts.num_double):
                     yield data.VariableMessage(
                         continuous=data.Array(
-                            name=jac[0],
-                            subname=jac[1],
+                            name=key[0],
+                            subname=key[1],
                             type=data.kPartial,
                             start=b,
                             end=e,


### PR DESCRIPTION
Fixes #71

- Renamed `for jac, value in jac.items():` loop variable to `for key, value in jac.items():` in `philote_mdo/general/explicit_server.py` and `philote_mdo/general/implicit_server.py` to prevent variable shadowing of the `jac` dictionary during gradient RPC streaming.