### PR TITLE
Send resolved OpenMDAO options to the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Fixed `RemoteExplicitComponent` and `RemoteImplicitComponent` sending the raw
+  constructor keyword arguments to the server rather than the component's
+  resolved options.  An option that reached the component by any other route --
+  an OpenMDAO default, or an assignment such as `comp.options['dimension'] = 10`
+  after construction -- never reached the server, which kept computing with
+  whatever it had.  The failure was silent: the component reported the option as
+  set while the server used a different value.  The options are now read from
+  `comp.options`, restricted to the names the server declared, and transmitted
+  during `setup()` immediately before the remote `Setup` call, so post-
+  construction assignment takes effect.  Options declared without a value are
+  skipped, leaving the server on its own default (#77).
 - Fixed `ImplicitServer` emitting `Array.end` as an exclusive index, while the
   explicit server and both clients treat it as inclusive per the standard.  Any
   implicit variable spanning more than one chunk failed to decode; single-chunk

--- a/docs/docs/openmdao/openmdao-clients.md
+++ b/docs/docs/openmdao/openmdao-clients.md
@@ -106,6 +106,21 @@ print(f"Optimal x: {prob['x']}")
 print(f"Optimal objective: {prob['f_xy']}")
 ```
 
+Server options can also be assigned after the component is constructed, as
+long as it happens before `prob.setup()`:
+
+```python
+component = pmom.RemoteExplicitComponent(channel=channel)
+component.options["tolerance"] = 1e-8
+
+prob.setup()   # the resolved options are sent to the server here
+```
+
+The component transmits its resolved options to the server during `setup()`,
+immediately before the remote setup runs. Only the options the server declared
+are sent; an option that was never assigned is left out, so the server keeps
+its own default.
+
 ## Remote Implicit Components
 
 ### Basic Usage

--- a/philote_mdo/openmdao/explicit.py
+++ b/philote_mdo/openmdao/explicit.py
@@ -143,13 +143,6 @@ class RemoteExplicitComponent(om.ExplicitComponent):
         # Initialize the parent OpenMDAO ExplicitComponent
         super().__init__(num_par_fd=num_par_fd, **kwargs)
 
-        # Send initial options to the server
-        # This must be done here and not in initialize, as the values of the
-        # OpenMDAO options are only set after initialize has been called in the
-        # parent init function. That is why the parent init function must be called
-        # before sending the option values to the Philote server.
-        self._client.send_options(kwargs)
-
     def initialize(self):
         """
         Define OpenMDAO component options based on server-available options.
@@ -183,6 +176,10 @@ class RemoteExplicitComponent(om.ExplicitComponent):
 
         The method is called automatically by OpenMDAO during problem setup and should
         not be called directly by users.
+
+        The component's resolved options are transmitted to the server before
+        the remote setup runs, so options assigned after construction take
+        effect.
 
         Notes
         -----

--- a/philote_mdo/openmdao/implicit.py
+++ b/philote_mdo/openmdao/implicit.py
@@ -150,13 +150,6 @@ class RemoteImplicitComponent(om.ImplicitComponent):
         # Initialize the parent OpenMDAO ImplicitComponent
         super().__init__(num_par_fd=num_par_fd, **kwargs)
 
-        # Send initial options to the server
-        # This must be done here and not in initialize, as the values of the
-        # OpenMDAO options are only set after initialize has been called in the
-        # parent init function. That is why the parent init function must be called
-        # before sending the option values to the Philote server.
-        self._client.send_options(kwargs)
-
     def initialize(self):
         """
         Define OpenMDAO component options based on server-available options.
@@ -191,6 +184,10 @@ class RemoteImplicitComponent(om.ImplicitComponent):
 
         The method is called automatically by OpenMDAO during problem setup and should
         not be called directly by users.
+
+        The component's resolved options are transmitted to the server before
+        the remote setup runs, so options assigned after construction take
+        effect.
 
         Notes
         -----

--- a/philote_mdo/openmdao/utils.py
+++ b/philote_mdo/openmdao/utils.py
@@ -57,6 +57,45 @@ def declare_options(opt_list, options):
         options.declare(name, types=opt_type)
 
 
+def option_is_set(options, name):
+    """
+    Checks whether an OpenMDAO option currently holds a value.
+
+    Options declared by :func:`declare_options` have no default, so an
+    option the user never assigned is declared but unset.  Reading it
+    raises, which is why it has to be filtered out before the options are
+    transmitted.
+    """
+    meta = getattr(options, "_dict", {}).get(name)
+
+    if meta is None:
+        return False
+
+    return bool(meta.get("has_been_set", True))
+
+
+def send_options(comp):
+    """
+    Sends the component's resolved options to the remote discipline server.
+
+    The resolved options are transmitted, not the keyword arguments the
+    component was constructed with, so values that reach the component by
+    another route (an OpenMDAO default, or an assignment after
+    construction) reach the server as well.
+
+    Only the options the server declared through ``GetAvailableOptions``
+    are forwarded, so unrelated OpenMDAO options are not sent.  Declared
+    but unset options are skipped, leaving the server on its own default.
+    """
+    options = {
+        name: comp.options[name]
+        for name in comp._client.options_list
+        if name in comp.options and option_is_set(comp.options, name)
+    }
+
+    comp._client.send_options(options)
+
+
 def client_setup(comp):
     """
     Sets up the OpenMDAO component with all required inputs and outputs.
@@ -65,6 +104,11 @@ def client_setup(comp):
     from the remote discipline server.  Both continuous and discrete
     variables are declared.
     """
+    # Send the options before the remote setup runs. The server derives its
+    # variable metadata from the options, and SetOptions is only meaningful
+    # ahead of Setup.
+    send_options(comp)
+
     # set up the remote discipline and get the variable definitions
     comp._client.run_setup()
     comp._client.get_variable_definitions()

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -453,6 +453,7 @@ class TestOpenMdaoUtilsDynamicShapes(unittest.TestCase):
 
         comp._client._var_meta = [var]
         comp._client._discrete_var_meta = []
+        comp._client.options_list = {}
 
         from philote_mdo.openmdao.utils import client_setup
 
@@ -474,6 +475,7 @@ class TestOpenMdaoUtilsDynamicShapes(unittest.TestCase):
 
         comp._client._var_meta = [var]
         comp._client._discrete_var_meta = []
+        comp._client.options_list = {}
 
         from philote_mdo.openmdao.utils import client_setup
 

--- a/tests/test_openmdao_explicit_client.py
+++ b/tests/test_openmdao_explicit_client.py
@@ -74,9 +74,10 @@ class TestOpenMdaoExplicitClient(unittest.TestCase):
             num_par_fd=num_par_fd, **options
         )
 
-        # Verify that send_options is called with the correct arguments
-        expected_send_options_args = options.copy()
-        comp._client.send_options.assert_called_once_with(expected_send_options_args)
+        # The options are sent at setup time from the resolved OpenMDAO
+        # options, not from the constructor kwargs, so nothing is
+        # transmitted during construction.
+        comp._client.send_options.assert_not_called()
 
     def test_initialize(self, om_explicit_component_patch):
         mock_channel = Mock()
@@ -314,6 +315,80 @@ class TestOpenMdaoExplicitClient(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             RemoteExplicitComponent(channel=mock_channel, num_par_fd=0)
         self.assertIn("num_par_fd must be a positive integer", str(context.exception))
+
+
+class TestOpenMdaoExplicitComponentOptions(unittest.TestCase):
+    """
+    Tests that the resolved options reach the server (issue #77).
+
+    These tests use the real OpenMDAO component machinery so the option
+    values are actually declared, validated and defaulted.
+    """
+
+    def _make_component(self, **kwargs):
+        client = MagicMock()
+        client.options_list = {"dimension": "int", "scale": "float"}
+        client._var_meta = []
+        client._discrete_var_meta = []
+
+        with patch("philote_mdo.general.ExplicitClient", return_value=client):
+            comp = RemoteExplicitComponent(channel=Mock(), **kwargs)
+
+        return comp, client
+
+    def test_constructor_does_not_send_options(self):
+        """
+        The constructor no longer sends the raw keyword arguments.
+        """
+        _, client = self._make_component(dimension=2)
+
+        client.send_options.assert_not_called()
+
+    def test_setup_sends_constructor_options(self):
+        """
+        Options passed to the constructor are sent when setup runs.
+        """
+        comp, client = self._make_component(dimension=2, scale=1.5)
+
+        comp.setup()
+
+        client.send_options.assert_called_once_with(
+            {"dimension": 2, "scale": 1.5}
+        )
+
+    def test_setup_sends_post_construction_assignment(self):
+        """
+        An option assigned after construction reaches the server.
+        """
+        comp, client = self._make_component(dimension=2, scale=1.5)
+        comp.options["dimension"] = 10
+
+        comp.setup()
+
+        client.send_options.assert_called_once_with(
+            {"dimension": 10, "scale": 1.5}
+        )
+
+    def test_setup_omits_unset_options(self):
+        """
+        An option the caller never set is left to the server's default.
+        """
+        comp, client = self._make_component(dimension=2)
+
+        comp.setup()
+
+        client.send_options.assert_called_once_with({"dimension": 2})
+
+    def test_setup_omits_unrelated_openmdao_options(self):
+        """
+        OpenMDAO options the server never declared are not forwarded.
+        """
+        comp, client = self._make_component(dimension=2)
+
+        comp.setup()
+
+        sent = client.send_options.call_args[0][0]
+        self.assertEqual(set(sent), {"dimension"})
 
 
 if __name__ == "__main__":

--- a/tests/test_openmdao_implicit_client.py
+++ b/tests/test_openmdao_implicit_client.py
@@ -75,9 +75,10 @@ class TestOpenMdaoImplicitClient(unittest.TestCase):
             num_par_fd=num_par_fd, **options
         )
 
-        # Verify that send_options is called with the correct arguments
-        expected_send_options_args = options.copy()
-        comp._client.send_options.assert_called_once_with(expected_send_options_args)
+        # The options are sent at setup time from the resolved OpenMDAO
+        # options, not from the constructor kwargs, so nothing is
+        # transmitted during construction.
+        comp._client.send_options.assert_not_called()
 
     def test_initialize(self, om_implicit_component_patch):
         """
@@ -376,6 +377,80 @@ class TestOpenMdaoImplicitClient(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             RemoteImplicitComponent(channel=mock_channel, num_par_fd=-1)
         self.assertIn("num_par_fd must be a positive integer", str(context.exception))
+
+
+class TestOpenMdaoImplicitComponentOptions(unittest.TestCase):
+    """
+    Tests that the resolved options reach the server (issue #77).
+
+    These tests use the real OpenMDAO component machinery so the option
+    values are actually declared, validated and defaulted.
+    """
+
+    def _make_component(self, **kwargs):
+        client = MagicMock()
+        client.options_list = {"dimension": "int", "scale": "float"}
+        client._var_meta = []
+        client._discrete_var_meta = []
+
+        with patch("philote_mdo.general.ImplicitClient", return_value=client):
+            comp = RemoteImplicitComponent(channel=Mock(), **kwargs)
+
+        return comp, client
+
+    def test_constructor_does_not_send_options(self):
+        """
+        The constructor no longer sends the raw keyword arguments.
+        """
+        _, client = self._make_component(dimension=2)
+
+        client.send_options.assert_not_called()
+
+    def test_setup_sends_constructor_options(self):
+        """
+        Options passed to the constructor are sent when setup runs.
+        """
+        comp, client = self._make_component(dimension=2, scale=1.5)
+
+        comp.setup()
+
+        client.send_options.assert_called_once_with(
+            {"dimension": 2, "scale": 1.5}
+        )
+
+    def test_setup_sends_post_construction_assignment(self):
+        """
+        An option assigned after construction reaches the server.
+        """
+        comp, client = self._make_component(dimension=2, scale=1.5)
+        comp.options["dimension"] = 10
+
+        comp.setup()
+
+        client.send_options.assert_called_once_with(
+            {"dimension": 10, "scale": 1.5}
+        )
+
+    def test_setup_omits_unset_options(self):
+        """
+        An option the caller never set is left to the server's default.
+        """
+        comp, client = self._make_component(dimension=2)
+
+        comp.setup()
+
+        client.send_options.assert_called_once_with({"dimension": 2})
+
+    def test_setup_omits_unrelated_openmdao_options(self):
+        """
+        OpenMDAO options the server never declared are not forwarded.
+        """
+        comp, client = self._make_component(dimension=2)
+
+        comp.setup()
+
+        sent = client.send_options.call_args[0][0]
+        self.assertEqual(set(sent), {"dimension"})
 
 
 if __name__ == "__main__":

--- a/tests/test_openmdao_integration.py
+++ b/tests/test_openmdao_integration.py
@@ -148,6 +148,49 @@ class OpenMDAOIntegrationTests(unittest.TestCase):
         # stop the server
         server.stop(0)
 
+    def test_rosenbrock_option_set_after_construction(self):
+        """
+        Integration test for an option assigned after the component is built.
+
+        The Rosenbrock discipline derives its variable shape from the
+        ``dimension`` option, so an assignment the server never hears about
+        shows up as a shape mismatch (issue #77).
+        """
+        # server code
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+
+        discipline = pmdo.ExplicitServer(discipline=Rosenbrock())
+        discipline.attach_to_server(server)
+
+        server.add_insecure_port("[::]:50051")
+        server.start()
+
+        # client code
+        prob = om.Problem()
+        model = prob.model
+
+        comp = pmdo_om.RemoteExplicitComponent(
+            channel=grpc.insecure_channel("localhost:50051"), dimension=2
+        )
+        model.add_subsystem("Rosenbrock", comp)
+
+        # override the option after the component was constructed
+        comp.options["dimension"] = 4
+
+        prob.setup()
+
+        # the server must have used the assigned dimension, not the one the
+        # constructor was given
+        self.assertEqual(prob.get_val("Rosenbrock.x").shape, (4,))
+
+        prob.set_val("Rosenbrock.x", np.zeros(4))
+        prob.run_model()
+
+        self.assertEqual(prob.get_val("Rosenbrock.f")[0], 3.0)
+
+        # stop the server
+        server.stop(0)
+
     def test_rosenbrock_compute_partials(self):
         """
         Integration test for the Paraboloid compute function.

--- a/tests/test_openmdao_utils.py
+++ b/tests/test_openmdao_utils.py
@@ -34,6 +34,26 @@ import numpy as np
 from philote_mdo.generated.data_pb2 import kInput, kOutput
 from philote_mdo.utils.validation import PhiloteValidationError
 import philote_mdo.openmdao.utils as utils
+from openmdao.utils.options_dictionary import OptionsDictionary
+
+
+def _options(values, unset=()):
+    """
+    Builds an OpenMDAO options dictionary with the given values.
+
+    Names listed in ``unset`` are declared without a default, mirroring
+    what ``declare_options`` does for an option the user never assigned.
+    """
+    options = OptionsDictionary()
+
+    for name, val in values.items():
+        options.declare(name, types=type(val))
+        options[name] = val
+
+    for name in unset:
+        options.declare(name, types=float)
+
+    return options
 
 
 class TestOpenMdaoUtils(unittest.TestCase):
@@ -59,11 +79,18 @@ class TestOpenMdaoUtils(unittest.TestCase):
 
         comp._client._var_meta = [var1, var2]
         comp._client._discrete_var_meta = []
+        comp._client.options_list = {}
 
         utils.client_setup(comp)
 
         comp._client.run_setup.assert_called_once()
         comp._client.get_variable_definitions.assert_called_once()
+
+        # the options have to reach the server before the remote setup runs
+        self.assertEqual(
+            [name for name, _, _ in comp._client.mock_calls][:2],
+            ["send_options", "run_setup"],
+        )
 
         expected_calls = [
             ("add_input", ("var1",), {"shape": (2,), "units": "m"}),
@@ -168,6 +195,60 @@ class TestOpenMdaoUtils(unittest.TestCase):
         self.assertEqual(outputs["output2"], 20)
         # ensure that other keys in outputs are unchanged
         self.assertEqual(outputs["output3"], None)
+
+    def test_send_options_uses_resolved_options(self):
+        """
+        Tests that the resolved options are sent, not the constructor kwargs.
+        """
+        comp = Mock()
+        comp._client.options_list = {"dimension": "int", "scale": "float"}
+        comp.options = _options({"dimension": 10, "scale": 2.5})
+
+        utils.send_options(comp)
+
+        comp._client.send_options.assert_called_once_with(
+            {"dimension": 10, "scale": 2.5}
+        )
+
+    def test_send_options_skips_unset_options(self):
+        """
+        Tests that a declared but unset option is not transmitted.
+
+        Options declared from the server's option list have no default, so
+        reading an unset one raises. It has to be left out and the server
+        left on its own default.
+        """
+        comp = Mock()
+        comp._client.options_list = {"dimension": "int", "scale": "float"}
+        comp.options = _options({"dimension": 10}, unset=["scale"])
+
+        utils.send_options(comp)
+
+        comp._client.send_options.assert_called_once_with({"dimension": 10})
+
+    def test_send_options_ignores_undeclared_options(self):
+        """
+        Tests that OpenMDAO options the server never declared are not sent.
+        """
+        comp = Mock()
+        comp._client.options_list = {"dimension": "int"}
+        comp.options = _options({"dimension": 10, "num_par_fd": 1})
+
+        utils.send_options(comp)
+
+        comp._client.send_options.assert_called_once_with({"dimension": 10})
+
+    def test_send_options_ignores_missing_options(self):
+        """
+        Tests that a server option with no matching OpenMDAO option is skipped.
+        """
+        comp = Mock()
+        comp._client.options_list = {"dimension": "int", "unknown": "int"}
+        comp.options = _options({"dimension": 10})
+
+        utils.send_options(comp)
+
+        comp._client.send_options.assert_called_once_with({"dimension": 10})
 
     def test_declare_options(self):
         """


### PR DESCRIPTION
Fixes #77.

## Problem

`RemoteExplicitComponent` and `RemoteImplicitComponent` sent the raw constructor keyword arguments to the server, not the component's resolved options. Any option value that reached the component by another route never made it across:

- an option left at its OpenMDAO default, and
- an assignment after construction, such as `comp.options['dimension'] = 10`.

The failure was silent. The component reported the option as set, the server computed with a different one, and the results were wrong rather than erroneous.

## Fix

A new `utils.send_options(comp)` builds the payload from `comp.options`, restricted to the names in `comp._client.options_list` so unrelated OpenMDAO options are not forwarded. Options that are declared but never assigned are skipped — `declare_options` gives them no default, so reading one raises, and leaving them out is what lets the server keep its own default.

`client_setup` calls it as its first act, immediately before `run_setup()`.

## On the re-send question

The issue asked whether a re-send belongs in `setup()` as well. The send **moved** there rather than being duplicated, and the constructor no longer sends anything.

Sending at construction cannot see post-construction assignment, so once setup sends, the constructor call is a redundant RPC that only ever carries a subset of the truth. Setup-time placement is also the only one that stays ahead of `Setup` by construction rather than by coincidence, which matters once #76 lands and `SetOptions` after `Setup` is refused with `FAILED_PRECONDITION`.

The cost: a server rejecting an option value now surfaces at `prob.setup()` instead of at construction. Nothing in the call path between the two needs options to be set, so nothing else moves.

## Tests

- `tests/test_openmdao_utils.py` — unit coverage for `send_options`: resolved values, unset options skipped, undeclared names filtered, and an ordering assertion that `send_options` precedes `run_setup`.
- `tests/test_openmdao_{explicit,implicit}_client.py` — new `...ComponentOptions` classes driving the real OpenMDAO option machinery against a mocked client, covering constructor kwargs, post-construction assignment, and unset options. The two constructor tests that pinned `send_options(kwargs)` now assert nothing is sent during construction.
- `tests/test_openmdao_integration.py` — `test_rosenbrock_option_set_after_construction` builds with `dimension=2`, assigns `4`, and checks the server's variable shape over real gRPC. It fails on the pre-fix code with `(2,) != (4,)`.

Full suite: 324 passed.

Docs and `CHANGELOG.md` updated in the same commit.