### PR TITLE
Fix client metadata accumulating across repeated setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The server now populates the `name` and `version` fields of
   `DisciplineProperties` from the discipline's `_name` / `_version`
   attributes, and the client stores them (#67).
+- `DisciplineClient.get_partials_definitions` guarded against duplicates by
+  testing a `str` against a list of `PartialsMetaData` messages, so the guard
+  never fired and every message was appended unconditionally.  Both
+  `get_variable_definitions` and `get_partials_definitions` now clear their
+  metadata lists before repopulating them, mirroring the `_clear_data()` the
+  server performs at the start of each `Setup`, so a client that is set up
+  more than once replaces its metadata rather than accumulating duplicate
+  Jacobian preallocations and `declare_partials` calls (#78).
 
 ### Documentation & Infrastructure
 

--- a/philote_mdo/general/discipline_client.py
+++ b/philote_mdo/general/discipline_client.py
@@ -145,7 +145,15 @@ class DisciplineClient:
 
         Both continuous and discrete variable metadata are stored in their
         respective lists.
+
+        The local metadata is replaced rather than appended to, so that
+        calling this more than once on the same client (for instance when a
+        client is reused across jobs) mirrors the server, which clears its
+        metadata at the start of every ``Setup``.
         """
+        self._var_meta = []
+        self._discrete_var_meta = []
+
         for message in self._disc_stub.GetVariableDefinitions(empty.Empty()):
             if message.type in (
                 data.VariableType.kDiscreteInput,
@@ -158,10 +166,15 @@ class DisciplineClient:
     def get_partials_definitions(self):
         """
         Requests metadata information on the partials from the analysis server.
+
+        As with ``get_variable_definitions``, the local metadata is replaced
+        rather than appended to, so repeated calls do not accumulate duplicate
+        partials entries.
         """
+        self._partials_meta = []
+
         for message in self._disc_stub.GetPartialDefinitions(empty.Empty()):
-            if message.name not in self._partials_meta:
-                self._partials_meta += [message]
+            self._partials_meta += [message]
 
     def get_dynamic_variables(self):
         """

--- a/tests/test_discipline_client.py
+++ b/tests/test_discipline_client.py
@@ -291,6 +291,58 @@ class TestDisciplineClient(unittest.TestCase):
         self.assertEqual(client._partials_meta[1].name, "input2")
         self.assertEqual(client._partials_meta[1].subname, "output2")
 
+    @patch("philote_mdo.generated.disciplines_pb2_grpc.DisciplineServiceStub")
+    def test_get_variable_definitions_repeated_call(self, mock_discipline_stub):
+        """
+        Tests that repeated calls to get_variable_definitions replace, rather
+        than accumulate, the local variable metadata.
+        """
+        mock_channel = Mock()
+        mock_stub = mock_discipline_stub.return_value
+        client = DisciplineClient(mock_channel)
+
+        mock_stub.GetVariableDefinitions.return_value = [
+            data.VariableMetaData(
+                name="x", shape=[2, 2], units="m", type=data.VariableType.kInput
+            ),
+            data.VariableMetaData(
+                name="f", shape=[1], units="m**2", type=data.VariableType.kOutput
+            ),
+            data.VariableMetaData(
+                name="n", type=data.VariableType.kDiscreteInput
+            ),
+        ]
+
+        client.get_variable_definitions()
+        client.get_variable_definitions()
+
+        self.assertEqual(len(client._var_meta), 2)
+        self.assertEqual(len(client._discrete_var_meta), 1)
+
+    @patch("philote_mdo.generated.disciplines_pb2_grpc.DisciplineServiceStub")
+    def test_get_partial_definitions_repeated_call(self, mock_discipline_stub):
+        """
+        Tests that repeated calls to get_partials_definitions replace, rather
+        than accumulate, the local partials metadata.
+        """
+        mock_channel = Mock()
+        mock_stub = mock_discipline_stub.return_value
+        client = DisciplineClient(mock_channel)
+
+        mock_stub.GetPartialDefinitions.return_value = [
+            data.PartialsMetaData(name="f", subname="x"),
+            data.PartialsMetaData(name="f", subname="y"),
+        ]
+
+        client.get_partials_definitions()
+        client.get_partials_definitions()
+
+        self.assertEqual(len(client._partials_meta), 2)
+        self.assertEqual(
+            [(p.name, p.subname) for p in client._partials_meta],
+            [("f", "x"), ("f", "y")],
+        )
+
     def test_assemble_input_messages(self):
         """
         Tests the _assemble_input_messages function of the Discipline Client.


### PR DESCRIPTION
Fixes #78.

## Problem

The dedup guard in `DisciplineClient.get_partials_definitions` compared a `str` against a list of `PartialsMetaData` messages, so `message.name not in self._partials_meta` was always true and every streamed message was appended unconditionally. `get_variable_definitions` had the same append-rather-than-replace shape a few lines above, with no guard at all.

Latent today — nothing in the repo sets a client up twice — but reachable as soon as a client is reused across jobs. A second setup would leave `_recover_partials` preallocating the same Jacobian block repeatedly and `declare_partials` in the OpenMDAO binding declaring each pair more than once.

## Fix

Both methods now clear their metadata lists before repopulating them, which mirrors the `_clear_data()` the server performs at the start of each `Setup`. The broken guard is dropped rather than repaired — with the list cleared each call there is nothing left to dedup against.

This takes the second option the issue proposed, and extends it to `get_variable_definitions` so the two getters behave the same way.

## Tests

Two regression tests in `tests/test_discipline_client.py` call each getter twice against the same mocked stream and assert the counts do not double; both fail on the current `develop` (4 partials instead of 2). Full suite passes: 311 passed, 15 subtests passed.