### PR TITLE
Register implicit residual metadata and disambiguate partial shape lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The server now populates the `name` and `version` fields of
   `DisciplineProperties` from the discipline's `_name` / `_version`
   attributes, and the client stores them (#67).
+- `Discipline.add_output` appended the residual metadata an implicit
+  discipline needs, but never registered it in the duplicate-name index, so
+  the guard covered the output and not its residual.  The residual key is now
+  registered alongside the output (#79).
+- The shape lookup behind `DisciplineServer.preallocate_partials` and
+  `DisciplineClient._recover_partials` was keyed on the variable name alone,
+  so for an implicit discipline the residual entry shadowed the output that
+  shares its name and every partial was sized against whichever came last in
+  the metadata list.  Both sites now index by `(type, name)` and resolve the
+  function against the residual and the variable against the input or output,
+  matching how `SetVariableShapes` already indexes.  An unknown name now
+  raises `PhiloteValidationError` instead of `KeyError` (#79).
 
 ### Documentation & Infrastructure
 

--- a/philote_mdo/general/discipline.py
+++ b/philote_mdo/general/discipline.py
@@ -217,14 +217,16 @@ class Discipline:
 
         if self._is_implicit:
             res_meta = data.VariableMetaData()
-            res_meta.type = data.VariableType.kOutput
+            res_meta.type = data.VariableType.kResidual
             res_meta.name = name
             if not dynamic_shape:
                 res_meta.shape.extend(shape)
             res_meta.units = units
-            res_meta.type = data.VariableType.kResidual
             res_meta.dynamic_shape = dynamic_shape
             self._var_meta += [res_meta]
+            # the residual is a separate entry in the metadata list, so it
+            # also has to be registered for the duplicate check to cover it
+            self._declared.add((data.VariableType.kResidual, name))
 
     def declare_partials(self, func, var):
         """

--- a/philote_mdo/general/discipline_client.py
+++ b/philote_mdo/general/discipline_client.py
@@ -390,13 +390,14 @@ class DisciplineClient:
         flat_p = utils.PairDict()
 
         # preallocate
-        # index the metadata by name once; scanning it per partial is
+        # index the metadata by (type, name) once; scanning it per partial is
         # quadratic in the number of variables
-        shapes = {var.name: tuple(var.shape) for var in self._var_meta}
+        shapes = utils.build_shape_index(self._var_meta)
 
         for part in self._partials_meta:
             shape = utils.get_partials_shape(
-                shapes[part.name], shapes[part.subname]
+                utils.get_function_shape(shapes, part.name, "_recover_partials"),
+                utils.get_variable_shape(shapes, part.subname, "_recover_partials"),
             )
 
             partials[(part.name, part.subname)] = np.zeros(shape)

--- a/philote_mdo/general/discipline_server.py
+++ b/philote_mdo/general/discipline_server.py
@@ -36,8 +36,11 @@ from google.protobuf.empty_pb2 import Empty
 from google.protobuf import struct_pb2
 from philote_mdo.utils import (
     PairDict,
+    build_shape_index,
     get_flattened_view,
+    get_function_shape,
     get_partials_shape,
+    get_variable_shape,
     read_array_into,
 )
 from philote_mdo.utils.validation import PhiloteValidationError, validate_shape
@@ -273,12 +276,15 @@ class DisciplineServer(disc.DisciplineService):
         """
         jac = PairDict()
 
-        # index the metadata by name once; scanning it per partial is
+        # index the metadata by (type, name) once; scanning it per partial is
         # quadratic in the number of variables
-        shapes = {var.name: tuple(var.shape) for var in self._discipline._var_meta}
+        shapes = build_shape_index(self._discipline._var_meta)
 
         for pair in self._discipline._partials_meta:
-            shape = get_partials_shape(shapes[pair.name], shapes[pair.subname])
+            shape = get_partials_shape(
+                get_function_shape(shapes, pair.name, "preallocate_partials"),
+                get_variable_shape(shapes, pair.subname, "preallocate_partials"),
+            )
 
             jac[(pair.name, pair.subname)] = np.zeros(shape)
 

--- a/philote_mdo/utils/__init__.py
+++ b/philote_mdo/utils/__init__.py
@@ -34,7 +34,14 @@ from .encoding import (
     read_array_into,
     set_array_data,
 )
-from .helper import get_chunk_indices, get_flattened_view, get_partials_shape
+from .helper import (
+    build_shape_index,
+    get_chunk_indices,
+    get_flattened_view,
+    get_function_shape,
+    get_partials_shape,
+    get_variable_shape,
+)
 from .validation import (
     PhiloteError,
     PhiloteValidationError,

--- a/philote_mdo/utils/helper.py
+++ b/philote_mdo/utils/helper.py
@@ -29,6 +29,7 @@
 # control over the information you may find at these locations.
 import numpy as np
 
+import philote_mdo.generated.data_pb2 as data
 from philote_mdo.utils.validation import PhiloteValidationError
 
 
@@ -99,3 +100,67 @@ def get_flattened_view(arr):
     flat_view = arr.view()
     flat_view.shape = -1
     return flat_view
+
+
+# a partial is always the derivative of a function with respect to a
+# variable. the function is an output (explicit) or a residual (implicit),
+# and the variable is an input or, for implicit disciplines, an output. the
+# residual carries the same name as its output, so the lookup order below is
+# what disambiguates the two entries in the metadata list.
+_FUNCTION_TYPES = (data.VariableType.kResidual, data.VariableType.kOutput)
+_VARIABLE_TYPES = (data.VariableType.kInput, data.VariableType.kOutput)
+
+
+def build_shape_index(var_meta):
+    """
+    Indexes the shapes of continuous variable metadata by (type, name).
+
+    Indexing on the name alone is ambiguous for implicit disciplines, where
+    an output and its residual share a name, and would resolve every lookup
+    against whichever of the two comes last in the metadata list.
+
+    :param var_meta: iterable of VariableMetaData
+    :return: dictionary mapping (type, name) to the shape, as a tuple
+    """
+    index = {}
+
+    for var in var_meta:
+        index.setdefault((var.type, var.name), tuple(var.shape))
+
+    return index
+
+
+def get_function_shape(shape_index, name, context):
+    """
+    Returns the shape of the function a partial is taken of, preferring the
+    residual entry over the output entry of the same name.
+
+    :param shape_index: index built by build_shape_index
+    :param name: name of the function
+    :param context: name of the caller, used in the error message
+    :return: shape of the function, as a tuple
+    """
+    return _lookup_shape(shape_index, name, _FUNCTION_TYPES, context)
+
+
+def get_variable_shape(shape_index, name, context):
+    """
+    Returns the shape of the variable a partial is taken with respect to,
+    preferring the input entry over the output entry of the same name.
+
+    :param shape_index: index built by build_shape_index
+    :param name: name of the variable
+    :param context: name of the caller, used in the error message
+    :return: shape of the variable, as a tuple
+    """
+    return _lookup_shape(shape_index, name, _VARIABLE_TYPES, context)
+
+
+def _lookup_shape(shape_index, name, types, context):
+    for var_type in types:
+        if (var_type, name) in shape_index:
+            return shape_index[(var_type, name)]
+
+    raise PhiloteValidationError(
+        f"{context}: no variable metadata found for '{name}'."
+    )

--- a/tests/test_discipline.py
+++ b/tests/test_discipline.py
@@ -252,6 +252,37 @@ class TestDiscipline(unittest.TestCase):
         with self.assertRaises(PhiloteValidationError):
             disc.add_output("y")
 
+    def test_implicit_add_output_registers_the_residual(self):
+        """
+        The residual entry an implicit discipline adds alongside its output
+        must be covered by the duplicate index as well.
+        """
+        disc = Discipline()
+        disc._is_implicit = True
+        disc.add_output("x", shape=(2,), units="m")
+
+        types = [var.type for var in disc._var_meta]
+        self.assertEqual(
+            types, [data.VariableType.kOutput, data.VariableType.kResidual]
+        )
+        self.assertIn((data.VariableType.kOutput, "x"), disc._declared)
+        self.assertIn((data.VariableType.kResidual, "x"), disc._declared)
+
+    def test_implicit_clear_data_permits_redeclaration(self):
+        """
+        Clearing the metadata must also drop the residual key, otherwise the
+        output cannot be redeclared without leaving a stale entry behind.
+        """
+        disc = Discipline()
+        disc._is_implicit = True
+        disc.add_output("x", shape=(2,))
+
+        disc._clear_data()
+        disc.add_output("x", shape=(2,))
+
+        self.assertEqual(len(disc._var_meta), 2)
+        self.assertIn((data.VariableType.kResidual, "x"), disc._declared)
+
     def test_add_option_invalid_name(self):
         disc = Discipline()
         with self.assertRaises(PhiloteValidationError):

--- a/tests/test_discipline_client.py
+++ b/tests/test_discipline_client.py
@@ -484,6 +484,46 @@ class TestDisciplineClient(unittest.TestCase):
             self.assertTrue((name, subname) in partials)
             np.testing.assert_array_equal(partials[(name, subname)], expected_data)
 
+    def test_recover_partials_implicit_uses_the_residual_shape(self):
+        """
+        For an implicit discipline the metadata contains an output and a
+        residual of the same name. The partial is taken of the residual, so
+        the preallocation must resolve against that entry.
+        """
+        mock_channel = Mock()
+        client = DisciplineClient(mock_channel)
+
+        client._var_meta = [
+            data.VariableMetaData(name="x", type=data.kInput, shape=(3,)),
+            data.VariableMetaData(name="y", type=data.kOutput, shape=(2,)),
+            data.VariableMetaData(name="y", type=data.kResidual, shape=(4,)),
+        ]
+        client._partials_meta = [
+            data.PartialsMetaData(name="y", subname="x"),
+            data.PartialsMetaData(name="y", subname="y"),
+        ]
+
+        partials = client._recover_partials([])
+
+        self.assertEqual(partials[("y", "x")].shape, (4, 3))
+        self.assertEqual(partials[("y", "y")].shape, (4, 2))
+
+    def test_recover_partials_unknown_variable(self):
+        """
+        A partial declared against metadata the client never received reports
+        a validation error rather than a bare KeyError.
+        """
+        mock_channel = Mock()
+        client = DisciplineClient(mock_channel)
+
+        client._var_meta = [
+            data.VariableMetaData(name="f", type=data.kOutput, shape=(1,)),
+        ]
+        client._partials_meta = [data.PartialsMetaData(name="f", subname="missing")]
+
+        with self.assertRaises(PhiloteValidationError):
+            client._recover_partials([])
+
     def test_recover_outputs_empty_array_raises_error(self):
         """
         Tests that _recover_outputs raises ValueError when array data is empty.

--- a/tests/test_discipline_server.py
+++ b/tests/test_discipline_server.py
@@ -324,6 +324,48 @@ class TestDisciplineServer(unittest.TestCase):
             self.assertIsInstance(jac[pair], np.ndarray)
             self.assertEqual(jac[pair].shape, shape)
 
+    def test_preallocate_partials_implicit_uses_the_residual_shape(self):
+        """
+        For an implicit discipline the partial is taken of the residual, so
+        the function shape must be resolved against the residual entry and
+        not against the output that shares its name.
+        """
+        server = DisciplineServer()
+        discipline = server._discipline = Discipline()
+        discipline._is_implicit = True
+        discipline.add_input("x", shape=(3,), units="m")
+        discipline.add_output("y", shape=(2,), units="m")
+
+        # force the two entries apart so that the lookup is observable
+        residual = discipline._var_meta[-1]
+        self.assertEqual(residual.type, data.VariableType.kResidual)
+        residual.shape[:] = []
+        residual.shape.extend((4,))
+
+        discipline.declare_partials("y", "x")
+        discipline.declare_partials("y", "y")
+
+        jac = server.preallocate_partials()
+
+        # d(residual y)/dx uses the residual (4,) and the input (3,)
+        self.assertEqual(jac[("y", "x")].shape, (4, 3))
+        # d(residual y)/dy uses the residual (4,) and the output (2,)
+        self.assertEqual(jac[("y", "y")].shape, (4, 2))
+
+    def test_preallocate_partials_unknown_variable(self):
+        """
+        A partial declared against a variable that was never added reports a
+        validation error rather than a bare KeyError.
+        """
+        server = DisciplineServer()
+        discipline = server._discipline = Discipline()
+        discipline.add_input("x", shape=(1,))
+        discipline.add_output("f", shape=(1,))
+        discipline.declare_partials("f", "missing")
+
+        with self.assertRaises(PhiloteValidationError):
+            server.preallocate_partials()
+
     def test_process_inputs(self):
         # create a mock request_iterator
         request_iterator = [


### PR DESCRIPTION
Fixes #79.

## Problem

`Discipline.add_output` appends a second `VariableMetaData` typed `kResidual` for implicit disciplines, but never registered that key in `_declared`. The duplicate-name index added in #74 therefore covered the output and not its residual, so the index and the metadata list could drift.

The same name collision showed up downstream: `DisciplineServer.preallocate_partials` and `DisciplineClient._recover_partials` both built `shapes = {var.name: tuple(var.shape) for var in ..._var_meta}`. The residual comes after the output in the list, so it overwrote the output entry and *every* partial of an implicit discipline was sized against the residual, on both sides of the pair. Benign while the two shapes agree, wrong the moment they diverge.

## Changes

- `add_output` registers `(kResidual, name)` alongside `(kOutput, name)`, and the dead `res_meta.type = kOutput` assignment that was immediately overwritten is gone.
- New shared helpers in `philote_mdo/utils/helper.py`: `build_shape_index` (keyed on `(type, name)`), `get_function_shape` (residual first, then output) and `get_variable_shape` (input first, then output). A partial is always d(function)/d(variable), where the function is an output for an explicit discipline or a residual for an implicit one, and the variable is an input or, for implicit disciplines, an output — the lookup order encodes exactly that.
- Both partial-preallocation sites use those helpers, so they now agree with `SetVariableShapes`, which already indexes by `(type, name)`.
- A partial declared against a name with no metadata raises `PhiloteValidationError` instead of a bare `KeyError`.

The wire protocol is unchanged; this is all local metadata bookkeeping.

## Tests

Six new tests: residual registration and redeclaration after `_clear_data` (`test_discipline.py`), and the diverged-shape lookup plus the unknown-name error on both the server and the client. All six fail against the pre-fix source and pass after. Full suite: 315 passed.

## Changelog

Two entries under `[Unreleased] → Bug Fixes`.