### PR TITLE
Derive DisciplineServer from the servicer base class (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- `DisciplineServer` inherited `DisciplineService`, the generated experimental
+  static-call API, rather than `DisciplineServiceServicer`, the servicer base
+  that `add_DisciplineServiceServicer_to_server` is written against.  No
+  shipping code path reached the difference, because `DisciplineServer`
+  overrides all eight RPCs itself, but the class did not inherit the
+  `UNIMPLEMENTED` defaults a servicer base provides.  An RPC left undefined --
+  for instance one added to the `.proto` and not yet implemented -- resolved
+  instead to a static client stub, which registers without complaint and then
+  fails at call time by treating the `ServicerContext` as a target address,
+  raising out of the handler without setting a status, so the caller saw
+  `UNKNOWN` rather than `UNIMPLEMENTED`.  The base is now
+  `DisciplineServiceServicer`, matching `ExplicitServer` and `ImplicitServer`
+  (#70).
+
 - Fixed `RemoteExplicitComponent` and `RemoteImplicitComponent` sending the raw
   constructor keyword arguments to the server rather than the component's
   resolved options.  An option that reached the component by any other route --

--- a/philote_mdo/general/discipline_server.py
+++ b/philote_mdo/general/discipline_server.py
@@ -46,7 +46,7 @@ from philote_mdo.utils import (
 from philote_mdo.utils.validation import PhiloteValidationError, validate_shape
 
 
-class DisciplineServer(disc.DisciplineService):
+class DisciplineServer(disc.DisciplineServiceServicer):
     """
     Base class for all server classes.
     """

--- a/tests/test_discipline_server.py
+++ b/tests/test_discipline_server.py
@@ -38,6 +38,7 @@ from google.protobuf.empty_pb2 import Empty
 from philote_mdo.general import Discipline, DisciplineServer
 from philote_mdo.utils.validation import PhiloteValidationError
 import philote_mdo.generated.data_pb2 as data
+import philote_mdo.generated.disciplines_pb2_grpc as disc
 
 
 class TestDisciplineServer(unittest.TestCase):
@@ -609,6 +610,31 @@ class TestDisciplineServer(unittest.TestCase):
         args = context.abort.call_args
         self.assertEqual(args[0][0], grpc.StatusCode.INTERNAL)
         self.assertIn("Setup failed", args[0][1])
+
+    def test_servicer_base_class(self):
+        """
+        Tests that the server derives from the servicer, not the static API.
+        """
+        self.assertTrue(issubclass(DisciplineServer, disc.DisciplineServiceServicer))
+        self.assertNotIn(disc.DisciplineService, DisciplineServer.__mro__)
+
+    def test_missing_rpc_falls_back_to_servicer_default(self):
+        """
+        Tests that an RPC a subclass fails to define resolves to the servicer's
+        UNIMPLEMENTED default rather than to the static-call API.
+        """
+        skip = ("__dict__", "__weakref__", "GetInfo")
+        attrs = {k: v for k, v in vars(DisciplineServer).items() if k not in skip}
+        partial_cls = type("PartialServer", DisciplineServer.__bases__, attrs)
+
+        # the inherited GetInfo must come from the servicer, not the static API
+        self.assertIs(partial_cls.GetInfo, disc.DisciplineServiceServicer.GetInfo)
+
+        context = Mock()
+        with self.assertRaises(NotImplementedError):
+            partial_cls().GetInfo(Empty(), context)
+
+        context.set_code.assert_called_once_with(grpc.StatusCode.UNIMPLEMENTED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #70.

`DisciplineServer` derived from `disc.DisciplineService`, which despite the name
is the generated experimental *client-side* API — a set of `@staticmethod`s that
each open a one-shot channel to a target address. The servicer base that
`add_DisciplineServiceServicer_to_server` is written against is
`DisciplineServiceServicer`. `ExplicitServer` and `ImplicitServer` already mixed
in the correct servicers, so the inconsistency was confined to the base class.

## Impact

No shipping code path reached the difference. The registration helper looks
handlers up by name rather than by type, and `DisciplineServer` overrides all
eight RPCs itself, so the inherited staticmethods were always shadowed. This is
a latent-correctness fix, not a fix for an active bug.

What it protects is an RPC left undefined — realistically one added to the
`.proto` and regenerated but not yet implemented here. Note that the issue
describes that case incorrectly: it claims an `AttributeError` at registration
time. Registration actually succeeds, because the static API supplies the
attribute. The failure lands at call time instead, and its shape depends on
whether anything in the process has imported `grpc.experimental`:

- without it — `AttributeError: module 'grpc' has no attribute 'experimental'`
- with it — the staticmethod binds gRPC's `context` argument to its own `target`
  parameter and fails with `TypeError: Argument 'target' has incorrect type
  (expected bytes, got Mock)` while trying to dial the `ServicerContext` as a
  network address

Either way the handler raises without setting a status, so the client sees
`UNKNOWN` on a live request. After this change the servicer default sets
`UNIMPLEMENTED` and reports it properly.

## MRO

Both subclasses resolve cleanly:

- `ExplicitServer → DisciplineServer → DisciplineServiceServicer → ExplicitServiceServicer → object`
- `ImplicitServer → DisciplineServer → DisciplineServiceServicer → ImplicitServiceServicer → object`

## Tests

Two regression tests in `tests/test_discipline_server.py`: one asserts the base
class directly, the other rebuilds `DisciplineServer` without its own `GetInfo`
and checks the inherited method is the servicer's `UNIMPLEMENTED` default rather
than the static client stub. Both were confirmed to fail against the old base and
pass against the new one, so they catch a revert.

Full suite: 335 passed.